### PR TITLE
Missing dependences

### DIFF
--- a/bin/install-dependences.sh
+++ b/bin/install-dependences.sh
@@ -2,7 +2,8 @@
 sudo apt-get --yes --force-yes install \
    git make gcc numactl libnuma-dev \
    libmemcached-dev zlib1g-dev memcached \
-   libmemcached-dev libmemcached-tools libpapi-dev 
+   libmemcached-dev libmemcached-tools libpapi-dev \
+   libgsl-dev librdmacm-dev gcc-6
 
 wget https://github.com/ivmai/libatomic_ops/releases/download/v7.4.6/libatomic_ops-7.4.6.tar.gz
 


### PR DESCRIPTION
Added missing dependences to `install-dependences.sh` for `make` to work.